### PR TITLE
Pass domain objects by value instead of pointers

### DIFF
--- a/chi/crud-gorm/internal/api/handler/v1/article.go
+++ b/chi/crud-gorm/internal/api/handler/v1/article.go
@@ -18,8 +18,8 @@ import (
 )
 
 type ArticleService interface {
-	CreateArticle(ctx context.Context, article *domain.Article) (*domain.Article, error)
-	GetArticle(ctx context.Context, id uint) (*domain.Article, error)
+	CreateArticle(ctx context.Context, article domain.Article) (domain.Article, error)
+	GetArticle(ctx context.Context, id uint) (domain.Article, error)
 	ListArticles(ctx context.Context, page uint, perPage uint) ([]domain.Article, error)
 	SearchArticles(ctx context.Context, title, content string) ([]domain.Article, error)
 }
@@ -51,7 +51,7 @@ func (h *ArticleHandler) HandleCreateArticle(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	article, err := h.svc.CreateArticle(r.Context(), &domain.Article{
+	article, err := h.svc.CreateArticle(r.Context(), domain.Article{
 		UserID:  req.UserID,
 		Title:   req.Title,
 		Content: req.Content,
@@ -70,7 +70,7 @@ func (h *ArticleHandler) HandleCreateArticle(w http.ResponseWriter, r *http.Requ
 	}
 
 	render.Status(r, http.StatusCreated)
-	err = render.Render(w, r, response.NewArticle(article))
+	err = render.Render(w, r, response.NewArticle(&article))
 	if err != nil {
 		_ = render.Render(w, r, response.NewInternalServerError(err))
 
@@ -117,7 +117,7 @@ func (h *ArticleHandler) HandleGetArticle(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	err = render.Render(w, r, response.NewArticle(article))
+	err = render.Render(w, r, response.NewArticle(&article))
 	if err != nil {
 		_ = render.Render(w, r, response.NewInternalServerError(err))
 

--- a/chi/crud-gorm/internal/api/handler/v1/article_test.go
+++ b/chi/crud-gorm/internal/api/handler/v1/article_test.go
@@ -48,7 +48,7 @@ func TestArticleHandler_HandleCreateArticle(t *testing.T) {
 		buildReqBody func() string
 	}
 	type want struct {
-		article  *domain.Article
+		article  domain.Article
 		respCode int
 		err      *response.ErrResponse
 	}
@@ -64,8 +64,8 @@ func TestArticleHandler_HandleCreateArticle(t *testing.T) {
 			fields: fields{
 				setupService: func() ArticleService {
 					mock := service.NewArticleServiceMock()
-					mock.MockCreate = func(ctx context.Context, article *domain.Article) (*domain.Article, error) {
-						return &testArticleFoo, nil
+					mock.MockCreate = func(ctx context.Context, article domain.Article) (domain.Article, error) {
+						return testArticleFoo, nil
 					}
 					return mock
 				},
@@ -86,7 +86,7 @@ func TestArticleHandler_HandleCreateArticle(t *testing.T) {
 			},
 			want: want{
 				respCode: http.StatusCreated,
-				article:  &testArticleFoo,
+				article:  testArticleFoo,
 				err:      nil,
 			},
 			wantErr: false,
@@ -96,8 +96,8 @@ func TestArticleHandler_HandleCreateArticle(t *testing.T) {
 			fields: fields{
 				setupService: func() ArticleService {
 					mock := service.NewArticleServiceMock()
-					mock.MockCreate = func(ctx context.Context, article *domain.Article) (*domain.Article, error) {
-						return nil, testErr
+					mock.MockCreate = func(ctx context.Context, article domain.Article) (domain.Article, error) {
+						return domain.Article{}, testErr
 					}
 					return mock
 				},
@@ -117,7 +117,7 @@ func TestArticleHandler_HandleCreateArticle(t *testing.T) {
 				},
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusInternalServerError,
 				err:      response.NewInternalServerError(testErr),
 			},
@@ -192,8 +192,8 @@ func TestArticleHandler_HandleGetArticle(t *testing.T) {
 			fields: fields{
 				setupService: func() ArticleService {
 					mock := service.NewArticleServiceMock()
-					mock.MockGetArticle = func(ctx context.Context, id uint) (*domain.Article, error) {
-						return &testArticleFoo, nil
+					mock.MockGetArticle = func(ctx context.Context, id uint) (domain.Article, error) {
+						return testArticleFoo, nil
 					}
 					return mock
 				},
@@ -213,8 +213,8 @@ func TestArticleHandler_HandleGetArticle(t *testing.T) {
 			fields: fields{
 				setupService: func() ArticleService {
 					mock := service.NewArticleServiceMock()
-					mock.MockGetArticle = func(ctx context.Context, id uint) (*domain.Article, error) {
-						return nil, testErr
+					mock.MockGetArticle = func(ctx context.Context, id uint) (domain.Article, error) {
+						return domain.Article{}, testErr
 					}
 					return mock
 				},

--- a/chi/crud-gorm/internal/integration/db/article_test.go
+++ b/chi/crud-gorm/internal/integration/db/article_test.go
@@ -107,7 +107,7 @@ func (s *ArticleDBTestSuite) TestArticleDB_FindAll() {
 }
 
 func (s *ArticleDBTestSuite) TestArticleDB_Create() {
-	result, err := s.repo.Create(context.TODO(), &domain.Article{
+	result, err := s.repo.Create(context.TODO(), domain.Article{
 		UserID:  123,
 		Title:   "new title",
 		Content: "new content",

--- a/chi/crud-gorm/internal/integration/e2e/article_test.go
+++ b/chi/crud-gorm/internal/integration/e2e/article_test.go
@@ -102,7 +102,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleCreateArticle() {
 		buildReqBody func() string
 	}
 	type want struct {
-		article  *domain.Article
+		article  domain.Article
 		respCode int
 		err      *response.ErrResponse
 	}
@@ -129,7 +129,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleCreateArticle() {
 				},
 			},
 			want: want{
-				article: &domain.Article{
+				article: domain.Article{
 					UserID:  123,
 					Title:   "title 1",
 					Content: "content 1",
@@ -155,7 +155,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleCreateArticle() {
 				},
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusBadRequest,
 				err:      response.NewBadRequest("content: the length must be between 1 and 5000; title: the length must be between 1 and 128; user_id: cannot be blank."),
 			},
@@ -169,7 +169,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleCreateArticle() {
 				},
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusBadRequest,
 				err:      response.NewBadRequest("unexpected EOF"),
 			},
@@ -192,7 +192,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleCreateArticle() {
 				},
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusBadRequest,
 				err:      response.NewBadRequest("article already exists"),
 			},
@@ -238,7 +238,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleGetArticle() {
 		articleID string
 	}
 	type want struct {
-		article  *domain.Article
+		article  domain.Article
 		respCode int
 		err      *response.ErrResponse
 	}
@@ -254,7 +254,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleGetArticle() {
 				articleID: "999",
 			},
 			want: want{
-				article:  &testArticle999,
+				article:  testArticle999,
 				respCode: http.StatusOK,
 				err:      nil,
 			},
@@ -266,7 +266,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleGetArticle() {
 				articleID: "1",
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusNotFound,
 				err:      response.NewNotFound("article", "ID", "1"),
 			},
@@ -278,7 +278,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleGetArticle() {
 				articleID: "-1",
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusNotFound,
 				err:      response.NewNotFound("article", "ID", "-1"),
 			},
@@ -290,7 +290,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleGetArticle() {
 				articleID: "abc",
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusBadRequest,
 				err:      response.NewInvalidInput("articleID", "abc"),
 			},

--- a/chi/crud-gorm/internal/repository/article.go
+++ b/chi/crud-gorm/internal/repository/article.go
@@ -14,8 +14,8 @@ var (
 )
 
 type ArticleDAO interface {
-	Create(ctx context.Context, article *dao.Article) (*dao.Article, error)
-	FindByID(ctx context.Context, id uint) (*dao.Article, error)
+	Insert(ctx context.Context, article dao.Article) (dao.Article, error)
+	FindByID(ctx context.Context, id uint) (dao.Article, error)
 	FindAll(ctx context.Context, page, perPage uint) ([]dao.Article, error)
 	Search(ctx context.Context, title, content string) ([]dao.Article, error)
 }
@@ -30,25 +30,23 @@ func NewArticleRepository(dao ArticleDAO) *ArticleRepository {
 	}
 }
 
-func (r *ArticleRepository) Create(ctx context.Context, article *domain.Article) (*domain.Article, error) {
-	articleDAO := &dao.Article{
+func (r *ArticleRepository) Create(ctx context.Context, article domain.Article) (domain.Article, error) {
+	created, err := r.dao.Insert(ctx, dao.Article{
 		UserID:  article.UserID,
 		Title:   article.Title,
 		Content: article.Content,
-	}
-
-	created, err := r.dao.Create(ctx, articleDAO)
+	})
 	if err != nil {
-		return nil, fmt.Errorf("r.dao.Create -> %w", err)
+		return domain.Article{}, fmt.Errorf("r.dao.Insert -> %w", err)
 	}
 
 	return daoToDomain(created), nil
 }
 
-func (r *ArticleRepository) FindByID(ctx context.Context, id uint) (*domain.Article, error) {
+func (r *ArticleRepository) FindByID(ctx context.Context, id uint) (domain.Article, error) {
 	found, err := r.dao.FindByID(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("r.dao.FindByID -> %w", err)
+		return domain.Article{}, fmt.Errorf("r.dao.FindByID -> %w", err)
 	}
 
 	return daoToDomain(found), nil
@@ -62,7 +60,7 @@ func (r *ArticleRepository) FindAll(ctx context.Context, page, perPage uint) ([]
 
 	articles := make([]domain.Article, 0, len(allArticles))
 	for _, a := range allArticles {
-		articles = append(articles, *daoToDomain(&a))
+		articles = append(articles, daoToDomain(a))
 	}
 
 	return articles, nil
@@ -76,14 +74,14 @@ func (r *ArticleRepository) Search(ctx context.Context, title, content string) (
 
 	articles := make([]domain.Article, 0, len(allArticles))
 	for _, a := range allArticles {
-		articles = append(articles, *daoToDomain(&a))
+		articles = append(articles, daoToDomain(a))
 	}
 
 	return articles, nil
 }
 
-func daoToDomain(a *dao.Article) *domain.Article {
-	return &domain.Article{
+func daoToDomain(a dao.Article) domain.Article {
+	return domain.Article{
 		ID:        a.ID,
 		UserID:    a.UserID,
 		Title:     a.Title,

--- a/chi/crud-gorm/internal/repository/article_mock.go
+++ b/chi/crud-gorm/internal/repository/article_mock.go
@@ -7,17 +7,17 @@ import (
 )
 
 type ArticleRepositoryMock struct {
-	MockCreate   func(ctx context.Context, article *domain.Article) (*domain.Article, error)
-	MockFindByID func(ctx context.Context, id uint) (*domain.Article, error)
+	MockCreate   func(ctx context.Context, article domain.Article) (domain.Article, error)
+	MockFindByID func(ctx context.Context, id uint) (domain.Article, error)
 	MockFindAll  func(ctx context.Context, page, perPage uint) ([]domain.Article, error)
 	MockSearch   func(ctx context.Context, title, content string) ([]domain.Article, error)
 }
 
-func (m *ArticleRepositoryMock) Create(ctx context.Context, article *domain.Article) (*domain.Article, error) {
+func (m *ArticleRepositoryMock) Create(ctx context.Context, article domain.Article) (domain.Article, error) {
 	return m.MockCreate(ctx, article)
 }
 
-func (m *ArticleRepositoryMock) FindByID(ctx context.Context, id uint) (*domain.Article, error) {
+func (m *ArticleRepositoryMock) FindByID(ctx context.Context, id uint) (domain.Article, error) {
 	return m.MockFindByID(ctx, id)
 }
 

--- a/chi/crud-gorm/internal/repository/dao/article.go
+++ b/chi/crud-gorm/internal/repository/dao/article.go
@@ -33,33 +33,33 @@ func NewArticleDAO(db *gorm.DB) *ArticleDAO {
 	}
 }
 
-func (d *ArticleDAO) Create(ctx context.Context, article *Article) (*Article, error) {
-	result := d.db.WithContext(ctx).Create(article)
+func (d *ArticleDAO) Insert(ctx context.Context, article Article) (Article, error) {
+	result := d.db.WithContext(ctx).Create(&article)
 	if result.Error != nil {
 		var err *pgconn.PgError
 		if errors.As(result.Error, &err) && err.Code == pgerrcode.UniqueViolation {
-			return nil, ErrArticleDuplicated
+			return Article{}, ErrArticleDuplicated
 		}
 
-		return nil, result.Error
+		return Article{}, result.Error
 	}
 
 	return article, nil
 }
 
-func (d *ArticleDAO) FindByID(ctx context.Context, id uint) (*Article, error) {
+func (d *ArticleDAO) FindByID(ctx context.Context, id uint) (Article, error) {
 	var article Article
 
 	result := d.db.WithContext(ctx).First(&article, id)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, ErrArticleNotFound
+			return Article{}, ErrArticleNotFound
 		}
 
-		return nil, result.Error
+		return Article{}, result.Error
 	}
 
-	return &article, nil
+	return article, nil
 }
 
 func (d *ArticleDAO) FindAll(ctx context.Context, page, perPage uint) ([]Article, error) {

--- a/chi/crud-gorm/internal/service/article.go
+++ b/chi/crud-gorm/internal/service/article.go
@@ -14,8 +14,8 @@ var (
 )
 
 type ArticleRepository interface {
-	Create(ctx context.Context, article *domain.Article) (*domain.Article, error)
-	FindByID(ctx context.Context, id uint) (*domain.Article, error)
+	Create(ctx context.Context, article domain.Article) (domain.Article, error)
+	FindByID(ctx context.Context, id uint) (domain.Article, error)
 	FindAll(ctx context.Context, page, perPage uint) ([]domain.Article, error)
 	Search(ctx context.Context, title, content string) ([]domain.Article, error)
 }
@@ -30,19 +30,19 @@ func NewArticleService(repo ArticleRepository) *ArticleService {
 	}
 }
 
-func (s *ArticleService) CreateArticle(ctx context.Context, article *domain.Article) (*domain.Article, error) {
+func (s *ArticleService) CreateArticle(ctx context.Context, article domain.Article) (domain.Article, error) {
 	created, err := s.repo.Create(ctx, article)
 	if err != nil {
-		return nil, fmt.Errorf("s.repo.Create -> %w", err)
+		return domain.Article{}, fmt.Errorf("s.repo.Create -> %w", err)
 	}
 
 	return created, nil
 }
 
-func (s *ArticleService) GetArticle(ctx context.Context, id uint) (*domain.Article, error) {
+func (s *ArticleService) GetArticle(ctx context.Context, id uint) (domain.Article, error) {
 	article, err := s.repo.FindByID(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("s.repo.FindByID -> %w", err)
+		return domain.Article{}, fmt.Errorf("s.repo.FindByID -> %w", err)
 	}
 
 	return article, nil

--- a/chi/crud-gorm/internal/service/article_mock.go
+++ b/chi/crud-gorm/internal/service/article_mock.go
@@ -7,8 +7,8 @@ import (
 )
 
 type ArticleServiceMock struct {
-	MockCreate         func(ctx context.Context, article *domain.Article) (*domain.Article, error)
-	MockGetArticle     func(ctx context.Context, id uint) (*domain.Article, error)
+	MockCreate         func(ctx context.Context, article domain.Article) (domain.Article, error)
+	MockGetArticle     func(ctx context.Context, id uint) (domain.Article, error)
 	MockListArticles   func(ctx context.Context, page, perPage uint) ([]domain.Article, error)
 	MockSearchArticles func(ctx context.Context, title, content string) ([]domain.Article, error)
 }
@@ -17,11 +17,11 @@ func NewArticleServiceMock() *ArticleServiceMock {
 	return &ArticleServiceMock{}
 }
 
-func (m *ArticleServiceMock) CreateArticle(ctx context.Context, article *domain.Article) (*domain.Article, error) {
+func (m *ArticleServiceMock) CreateArticle(ctx context.Context, article domain.Article) (domain.Article, error) {
 	return m.MockCreate(ctx, article)
 }
 
-func (m *ArticleServiceMock) GetArticle(ctx context.Context, id uint) (*domain.Article, error) {
+func (m *ArticleServiceMock) GetArticle(ctx context.Context, id uint) (domain.Article, error) {
 	return m.MockGetArticle(ctx, id)
 }
 

--- a/chi/crud-gorm/internal/service/article_test.go
+++ b/chi/crud-gorm/internal/service/article_test.go
@@ -36,13 +36,13 @@ func TestArticleService_CreateArticle(t *testing.T) {
 	}
 	type args struct {
 		ctx     context.Context
-		article *domain.Article
+		article domain.Article
 	}
 	tests := []struct {
 		name       string
 		fields     fields
 		args       args
-		want       *domain.Article
+		want       domain.Article
 		wantErr    bool
 		wantErrMsg string
 	}{
@@ -50,16 +50,16 @@ func TestArticleService_CreateArticle(t *testing.T) {
 			name: "Happy Path",
 			fields: fields{
 				repo: &repository.ArticleRepositoryMock{
-					MockCreate: func(ctx context.Context, article *domain.Article) (*domain.Article, error) {
+					MockCreate: func(ctx context.Context, article domain.Article) (domain.Article, error) {
 						return article, nil
 					},
 				},
 			},
 			args: args{
 				ctx:     context.TODO(),
-				article: &testArticleFoo,
+				article: testArticleFoo,
 			},
-			want:       &testArticleFoo,
+			want:       testArticleFoo,
 			wantErr:    false,
 			wantErrMsg: "",
 		},
@@ -67,16 +67,16 @@ func TestArticleService_CreateArticle(t *testing.T) {
 			name: "Error Path",
 			fields: fields{
 				repo: &repository.ArticleRepositoryMock{
-					MockCreate: func(ctx context.Context, article *domain.Article) (*domain.Article, error) {
-						return nil, testErr
+					MockCreate: func(ctx context.Context, article domain.Article) (domain.Article, error) {
+						return domain.Article{}, testErr
 					},
 				},
 			},
 			args: args{
 				ctx:     context.TODO(),
-				article: &testArticleFoo,
+				article: testArticleFoo,
 			},
-			want:       nil,
+			want:       domain.Article{},
 			wantErr:    true,
 			wantErrMsg: "s.repo.Create -> something happened",
 		},
@@ -114,7 +114,7 @@ func TestArticleService_GetArticle(t *testing.T) {
 		name       string
 		fields     fields
 		args       args
-		want       *domain.Article
+		want       domain.Article
 		wantErr    bool
 		wantErrMsg string
 	}{
@@ -122,8 +122,8 @@ func TestArticleService_GetArticle(t *testing.T) {
 			name: "Happy Path",
 			fields: fields{
 				repo: &repository.ArticleRepositoryMock{
-					MockFindByID: func(ctx context.Context, id uint) (*domain.Article, error) {
-						return &testArticleFoo, nil
+					MockFindByID: func(ctx context.Context, id uint) (domain.Article, error) {
+						return testArticleFoo, nil
 					},
 				},
 			},
@@ -131,7 +131,7 @@ func TestArticleService_GetArticle(t *testing.T) {
 				ctx: context.TODO(),
 				id:  999,
 			},
-			want:       &testArticleFoo,
+			want:       testArticleFoo,
 			wantErr:    false,
 			wantErrMsg: "",
 		},
@@ -139,8 +139,8 @@ func TestArticleService_GetArticle(t *testing.T) {
 			name: "Error Path",
 			fields: fields{
 				repo: &repository.ArticleRepositoryMock{
-					MockFindByID: func(ctx context.Context, id uint) (*domain.Article, error) {
-						return nil, testErr
+					MockFindByID: func(ctx context.Context, id uint) (domain.Article, error) {
+						return domain.Article{}, testErr
 					},
 				},
 			},
@@ -148,7 +148,7 @@ func TestArticleService_GetArticle(t *testing.T) {
 				ctx: context.TODO(),
 				id:  testArticleFoo.ID,
 			},
-			want:       nil,
+			want:       domain.Article{},
 			wantErr:    true,
 			wantErrMsg: "s.repo.FindByID -> something happened",
 		},

--- a/gin/crud-gorm/internal/api/handler/v1/article.go
+++ b/gin/crud-gorm/internal/api/handler/v1/article.go
@@ -17,8 +17,8 @@ import (
 )
 
 type ArticleService interface {
-	CreateArticle(ctx context.Context, article *domain.Article) (*domain.Article, error)
-	GetArticle(ctx context.Context, id uint) (*domain.Article, error)
+	CreateArticle(ctx context.Context, article domain.Article) (domain.Article, error)
+	GetArticle(ctx context.Context, id uint) (domain.Article, error)
 	ListArticles(ctx context.Context, page, perPage uint) ([]domain.Article, error)
 	SearchArticles(ctx context.Context, title, content string) ([]domain.Article, error)
 }
@@ -56,7 +56,7 @@ func (h *ArticleHandler) HandleCreateArticle(ctx *gin.Context) {
 		return
 	}
 
-	article, err := h.svc.CreateArticle(ctx.Request.Context(), &domain.Article{
+	article, err := h.svc.CreateArticle(ctx.Request.Context(), domain.Article{
 		UserID:  req.UserID,
 		Title:   req.Title,
 		Content: req.Content,

--- a/gin/crud-gorm/internal/api/handler/v1/article_test.go
+++ b/gin/crud-gorm/internal/api/handler/v1/article_test.go
@@ -48,7 +48,7 @@ func TestArticleHandler_HandleCreateArticle(t *testing.T) {
 		buildReqBody func() string
 	}
 	type want struct {
-		article  *domain.Article
+		article  domain.Article
 		respCode int
 		err      *response.ErrResponse
 	}
@@ -64,8 +64,8 @@ func TestArticleHandler_HandleCreateArticle(t *testing.T) {
 			fields: fields{
 				setupService: func() ArticleService {
 					mock := service.NewArticleServiceMock()
-					mock.MockCreate = func(ctx context.Context, article *domain.Article) (*domain.Article, error) {
-						return &testArticleFoo, nil
+					mock.MockCreate = func(ctx context.Context, article domain.Article) (domain.Article, error) {
+						return testArticleFoo, nil
 					}
 					return mock
 				},
@@ -86,7 +86,7 @@ func TestArticleHandler_HandleCreateArticle(t *testing.T) {
 			},
 			want: want{
 				respCode: http.StatusCreated,
-				article:  &testArticleFoo,
+				article:  testArticleFoo,
 				err:      nil,
 			},
 			wantErr: false,
@@ -96,8 +96,8 @@ func TestArticleHandler_HandleCreateArticle(t *testing.T) {
 			fields: fields{
 				setupService: func() ArticleService {
 					mock := service.NewArticleServiceMock()
-					mock.MockCreate = func(ctx context.Context, article *domain.Article) (*domain.Article, error) {
-						return nil, testErr
+					mock.MockCreate = func(ctx context.Context, article domain.Article) (domain.Article, error) {
+						return domain.Article{}, testErr
 					}
 					return mock
 				},
@@ -117,7 +117,7 @@ func TestArticleHandler_HandleCreateArticle(t *testing.T) {
 				},
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusInternalServerError,
 				err:      response.NewInternalServerError(testErr),
 			},
@@ -177,7 +177,7 @@ func TestArticleHandler_HandleGetArticle(t *testing.T) {
 		articleID string
 	}
 	type want struct {
-		article  *domain.Article
+		article  domain.Article
 		respCode int
 		err      *response.ErrResponse
 	}
@@ -193,8 +193,8 @@ func TestArticleHandler_HandleGetArticle(t *testing.T) {
 			fields: fields{
 				setupService: func() ArticleService {
 					mock := service.NewArticleServiceMock()
-					mock.MockGetArticle = func(ctx context.Context, id uint) (*domain.Article, error) {
-						return &testArticleFoo, nil
+					mock.MockGetArticle = func(ctx context.Context, id uint) (domain.Article, error) {
+						return testArticleFoo, nil
 					}
 					return mock
 				},
@@ -203,7 +203,7 @@ func TestArticleHandler_HandleGetArticle(t *testing.T) {
 				articleID: "999",
 			},
 			want: want{
-				article:  &testArticleFoo,
+				article:  testArticleFoo,
 				respCode: http.StatusOK,
 				err:      nil,
 			},
@@ -213,8 +213,8 @@ func TestArticleHandler_HandleGetArticle(t *testing.T) {
 			fields: fields{
 				setupService: func() ArticleService {
 					mock := service.NewArticleServiceMock()
-					mock.MockGetArticle = func(ctx context.Context, id uint) (*domain.Article, error) {
-						return nil, testErr
+					mock.MockGetArticle = func(ctx context.Context, id uint) (domain.Article, error) {
+						return domain.Article{}, testErr
 					}
 					return mock
 				},
@@ -223,7 +223,7 @@ func TestArticleHandler_HandleGetArticle(t *testing.T) {
 				articleID: "999",
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusInternalServerError,
 				err:      response.NewInternalServerError(testErr),
 			},

--- a/gin/crud-gorm/internal/integration/db/article_test.go
+++ b/gin/crud-gorm/internal/integration/db/article_test.go
@@ -107,7 +107,7 @@ func (s *ArticleDBTestSuite) TestArticleDB_FindAll() {
 }
 
 func (s *ArticleDBTestSuite) TestArticleDB_Create() {
-	result, err := s.repo.Create(context.TODO(), &domain.Article{
+	result, err := s.repo.Create(context.TODO(), domain.Article{
 		UserID:  123,
 		Title:   "new title",
 		Content: "new content",

--- a/gin/crud-gorm/internal/integration/e2e/article_test.go
+++ b/gin/crud-gorm/internal/integration/e2e/article_test.go
@@ -109,7 +109,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleCreateArticle() {
 		buildReqBody func() string
 	}
 	type want struct {
-		article  *domain.Article
+		article  domain.Article
 		respCode int
 		err      *response.ErrResponse
 	}
@@ -136,7 +136,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleCreateArticle() {
 				},
 			},
 			want: want{
-				article: &domain.Article{
+				article: domain.Article{
 					UserID:  123,
 					Title:   "title 1",
 					Content: "content 1",
@@ -162,7 +162,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleCreateArticle() {
 				},
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusBadRequest,
 				err:      response.NewBadRequest("content: the length must be between 1 and 5000; title: the length must be between 1 and 128; user_id: cannot be blank."),
 			},
@@ -176,7 +176,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleCreateArticle() {
 				},
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusBadRequest,
 				err:      response.NewBadRequest("unexpected EOF"),
 			},
@@ -199,7 +199,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleCreateArticle() {
 				},
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusBadRequest,
 				err:      response.NewBadRequest("article already exists"),
 			},
@@ -245,7 +245,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleGetArticle() {
 		articleID string
 	}
 	type want struct {
-		article  *domain.Article
+		article  domain.Article
 		respCode int
 		err      *response.ErrResponse
 	}
@@ -261,7 +261,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleGetArticle() {
 				articleID: "999",
 			},
 			want: want{
-				article:  &testArticle999,
+				article:  testArticle999,
 				respCode: http.StatusOK,
 				err:      nil,
 			},
@@ -273,7 +273,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleGetArticle() {
 				articleID: "1",
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusNotFound,
 				err:      response.NewNotFound("article", "ID", "1"),
 			},
@@ -285,7 +285,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleGetArticle() {
 				articleID: "-1",
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusNotFound,
 				err:      response.NewNotFound("article", "ID", "-1"),
 			},
@@ -297,7 +297,7 @@ func (s *ArticleHandlerTestSuite) TestArticleHandler_HandleGetArticle() {
 				articleID: "abc",
 			},
 			want: want{
-				article:  nil,
+				article:  domain.Article{},
 				respCode: http.StatusBadRequest,
 				err:      response.NewInvalidInput("articleID", "abc"),
 			},

--- a/gin/crud-gorm/internal/repository/article.go
+++ b/gin/crud-gorm/internal/repository/article.go
@@ -14,8 +14,8 @@ var (
 )
 
 type ArticleDAO interface {
-	Create(ctx context.Context, article *dao.Article) (*dao.Article, error)
-	FindByID(ctx context.Context, id uint) (*dao.Article, error)
+	Insert(ctx context.Context, article dao.Article) (dao.Article, error)
+	FindByID(ctx context.Context, id uint) (dao.Article, error)
 	FindAll(ctx context.Context, page, perPage uint) ([]dao.Article, error)
 	Search(ctx context.Context, title, content string) ([]dao.Article, error)
 }
@@ -30,25 +30,23 @@ func NewArticleRepository(dao ArticleDAO) *ArticleRepository {
 	}
 }
 
-func (r *ArticleRepository) Create(ctx context.Context, article *domain.Article) (*domain.Article, error) {
-	articleDAO := &dao.Article{
+func (r *ArticleRepository) Create(ctx context.Context, article domain.Article) (domain.Article, error) {
+	created, err := r.dao.Insert(ctx, dao.Article{
 		UserID:  article.UserID,
 		Title:   article.Title,
 		Content: article.Content,
-	}
-
-	created, err := r.dao.Create(ctx, articleDAO)
+	})
 	if err != nil {
-		return nil, fmt.Errorf("r.dao.Create -> %w", err)
+		return domain.Article{}, fmt.Errorf("r.dao.Insert -> %w", err)
 	}
 
 	return daoToDomain(created), nil
 }
 
-func (r *ArticleRepository) FindByID(ctx context.Context, id uint) (*domain.Article, error) {
+func (r *ArticleRepository) FindByID(ctx context.Context, id uint) (domain.Article, error) {
 	found, err := r.dao.FindByID(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("r.dao.FindByID -> %w", err)
+		return domain.Article{}, fmt.Errorf("r.dao.FindByID -> %w", err)
 	}
 
 	return daoToDomain(found), nil
@@ -62,7 +60,7 @@ func (r *ArticleRepository) FindAll(ctx context.Context, page, perPage uint) ([]
 
 	articles := make([]domain.Article, 0, len(allArticles))
 	for _, a := range allArticles {
-		articles = append(articles, *daoToDomain(&a))
+		articles = append(articles, daoToDomain(a))
 	}
 
 	return articles, nil
@@ -76,14 +74,14 @@ func (r *ArticleRepository) Search(ctx context.Context, title, content string) (
 
 	articles := make([]domain.Article, 0, len(allArticles))
 	for _, a := range allArticles {
-		articles = append(articles, *daoToDomain(&a))
+		articles = append(articles, daoToDomain(a))
 	}
 
 	return articles, nil
 }
 
-func daoToDomain(a *dao.Article) *domain.Article {
-	return &domain.Article{
+func daoToDomain(a dao.Article) domain.Article {
+	return domain.Article{
 		ID:        a.ID,
 		UserID:    a.UserID,
 		Title:     a.Title,

--- a/gin/crud-gorm/internal/repository/article_mock.go
+++ b/gin/crud-gorm/internal/repository/article_mock.go
@@ -7,17 +7,17 @@ import (
 )
 
 type ArticleRepositoryMock struct {
-	MockCreate   func(ctx context.Context, article *domain.Article) (*domain.Article, error)
-	MockFindByID func(ctx context.Context, id uint) (*domain.Article, error)
+	MockCreate   func(ctx context.Context, article domain.Article) (domain.Article, error)
+	MockFindByID func(ctx context.Context, id uint) (domain.Article, error)
 	MockFindAll  func(ctx context.Context, page, perPage uint) ([]domain.Article, error)
 	MockSearch   func(ctx context.Context, title, content string) ([]domain.Article, error)
 }
 
-func (m *ArticleRepositoryMock) Create(ctx context.Context, article *domain.Article) (*domain.Article, error) {
+func (m *ArticleRepositoryMock) Create(ctx context.Context, article domain.Article) (domain.Article, error) {
 	return m.MockCreate(ctx, article)
 }
 
-func (m *ArticleRepositoryMock) FindByID(ctx context.Context, id uint) (*domain.Article, error) {
+func (m *ArticleRepositoryMock) FindByID(ctx context.Context, id uint) (domain.Article, error) {
 	return m.MockFindByID(ctx, id)
 }
 

--- a/gin/crud-gorm/internal/repository/dao/article.go
+++ b/gin/crud-gorm/internal/repository/dao/article.go
@@ -33,33 +33,33 @@ func NewArticleDAO(db *gorm.DB) *ArticleDAO {
 	}
 }
 
-func (d *ArticleDAO) Create(ctx context.Context, article *Article) (*Article, error) {
-	result := d.db.WithContext(ctx).Create(article)
+func (d *ArticleDAO) Insert(ctx context.Context, article Article) (Article, error) {
+	result := d.db.WithContext(ctx).Create(&article)
 	if result.Error != nil {
 		var err *pgconn.PgError
 		if errors.As(result.Error, &err) && err.Code == pgerrcode.UniqueViolation {
-			return nil, ErrArticleDuplicated
+			return Article{}, ErrArticleDuplicated
 		}
 
-		return nil, result.Error
+		return Article{}, result.Error
 	}
 
 	return article, nil
 }
 
-func (d *ArticleDAO) FindByID(ctx context.Context, id uint) (*Article, error) {
+func (d *ArticleDAO) FindByID(ctx context.Context, id uint) (Article, error) {
 	var article Article
 
 	result := d.db.WithContext(ctx).First(&article, id)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, ErrArticleNotFound
+			return Article{}, ErrArticleNotFound
 		}
 
-		return nil, result.Error
+		return Article{}, result.Error
 	}
 
-	return &article, nil
+	return article, nil
 }
 
 func (d *ArticleDAO) FindAll(ctx context.Context, page, perPage uint) ([]Article, error) {

--- a/gin/crud-gorm/internal/service/article.go
+++ b/gin/crud-gorm/internal/service/article.go
@@ -14,8 +14,8 @@ var (
 )
 
 type ArticleRepository interface {
-	Create(ctx context.Context, article *domain.Article) (*domain.Article, error)
-	FindByID(ctx context.Context, id uint) (*domain.Article, error)
+	Create(ctx context.Context, article domain.Article) (domain.Article, error)
+	FindByID(ctx context.Context, id uint) (domain.Article, error)
 	FindAll(ctx context.Context, page, perPage uint) ([]domain.Article, error)
 	Search(ctx context.Context, title, content string) ([]domain.Article, error)
 }
@@ -30,19 +30,19 @@ func NewArticleService(repo ArticleRepository) *ArticleService {
 	}
 }
 
-func (s *ArticleService) CreateArticle(ctx context.Context, article *domain.Article) (*domain.Article, error) {
+func (s *ArticleService) CreateArticle(ctx context.Context, article domain.Article) (domain.Article, error) {
 	created, err := s.repo.Create(ctx, article)
 	if err != nil {
-		return nil, fmt.Errorf("s.repo.Create -> %w", err)
+		return domain.Article{}, fmt.Errorf("s.repo.Create -> %w", err)
 	}
 
 	return created, nil
 }
 
-func (s *ArticleService) GetArticle(ctx context.Context, id uint) (*domain.Article, error) {
+func (s *ArticleService) GetArticle(ctx context.Context, id uint) (domain.Article, error) {
 	article, err := s.repo.FindByID(ctx, id)
 	if err != nil {
-		return nil, fmt.Errorf("s.repo.FindByID -> %w", err)
+		return domain.Article{}, fmt.Errorf("s.repo.FindByID -> %w", err)
 	}
 
 	return article, nil

--- a/gin/crud-gorm/internal/service/article_mock.go
+++ b/gin/crud-gorm/internal/service/article_mock.go
@@ -7,8 +7,8 @@ import (
 )
 
 type ArticleServiceMock struct {
-	MockCreate         func(ctx context.Context, article *domain.Article) (*domain.Article, error)
-	MockGetArticle     func(ctx context.Context, id uint) (*domain.Article, error)
+	MockCreate         func(ctx context.Context, article domain.Article) (domain.Article, error)
+	MockGetArticle     func(ctx context.Context, id uint) (domain.Article, error)
 	MockListArticles   func(ctx context.Context, page, perPage uint) ([]domain.Article, error)
 	MockSearchArticles func(ctx context.Context, title, content string) ([]domain.Article, error)
 }
@@ -17,11 +17,11 @@ func NewArticleServiceMock() *ArticleServiceMock {
 	return &ArticleServiceMock{}
 }
 
-func (m *ArticleServiceMock) CreateArticle(ctx context.Context, article *domain.Article) (*domain.Article, error) {
+func (m *ArticleServiceMock) CreateArticle(ctx context.Context, article domain.Article) (domain.Article, error) {
 	return m.MockCreate(ctx, article)
 }
 
-func (m *ArticleServiceMock) GetArticle(ctx context.Context, id uint) (*domain.Article, error) {
+func (m *ArticleServiceMock) GetArticle(ctx context.Context, id uint) (domain.Article, error) {
 	return m.MockGetArticle(ctx, id)
 }
 

--- a/gin/crud-gorm/internal/service/article_test.go
+++ b/gin/crud-gorm/internal/service/article_test.go
@@ -36,13 +36,13 @@ func TestArticleService_CreateArticle(t *testing.T) {
 	}
 	type args struct {
 		ctx     context.Context
-		article *domain.Article
+		article domain.Article
 	}
 	tests := []struct {
 		name       string
 		fields     fields
 		args       args
-		want       *domain.Article
+		want       domain.Article
 		wantErr    bool
 		wantErrMsg string
 	}{
@@ -50,16 +50,16 @@ func TestArticleService_CreateArticle(t *testing.T) {
 			name: "Happy Path",
 			fields: fields{
 				repo: &repository.ArticleRepositoryMock{
-					MockCreate: func(ctx context.Context, article *domain.Article) (*domain.Article, error) {
+					MockCreate: func(ctx context.Context, article domain.Article) (domain.Article, error) {
 						return article, nil
 					},
 				},
 			},
 			args: args{
 				ctx:     context.TODO(),
-				article: &testArticleFoo,
+				article: testArticleFoo,
 			},
-			want:       &testArticleFoo,
+			want:       testArticleFoo,
 			wantErr:    false,
 			wantErrMsg: "",
 		},
@@ -67,16 +67,16 @@ func TestArticleService_CreateArticle(t *testing.T) {
 			name: "Error Path",
 			fields: fields{
 				repo: &repository.ArticleRepositoryMock{
-					MockCreate: func(ctx context.Context, article *domain.Article) (*domain.Article, error) {
-						return nil, testErr
+					MockCreate: func(ctx context.Context, article domain.Article) (domain.Article, error) {
+						return domain.Article{}, testErr
 					},
 				},
 			},
 			args: args{
 				ctx:     context.TODO(),
-				article: &testArticleFoo,
+				article: testArticleFoo,
 			},
-			want:       nil,
+			want:       domain.Article{},
 			wantErr:    true,
 			wantErrMsg: "s.repo.Create -> something happened",
 		},
@@ -114,7 +114,7 @@ func TestArticleService_GetArticle(t *testing.T) {
 		name       string
 		fields     fields
 		args       args
-		want       *domain.Article
+		want       domain.Article
 		wantErr    bool
 		wantErrMsg string
 	}{
@@ -122,8 +122,8 @@ func TestArticleService_GetArticle(t *testing.T) {
 			name: "Happy Path",
 			fields: fields{
 				repo: &repository.ArticleRepositoryMock{
-					MockFindByID: func(ctx context.Context, id uint) (*domain.Article, error) {
-						return &testArticleFoo, nil
+					MockFindByID: func(ctx context.Context, id uint) (domain.Article, error) {
+						return testArticleFoo, nil
 					},
 				},
 			},
@@ -131,7 +131,7 @@ func TestArticleService_GetArticle(t *testing.T) {
 				ctx: context.TODO(),
 				id:  999,
 			},
-			want:       &testArticleFoo,
+			want:       testArticleFoo,
 			wantErr:    false,
 			wantErrMsg: "",
 		},
@@ -139,8 +139,8 @@ func TestArticleService_GetArticle(t *testing.T) {
 			name: "Error Path",
 			fields: fields{
 				repo: &repository.ArticleRepositoryMock{
-					MockFindByID: func(ctx context.Context, id uint) (*domain.Article, error) {
-						return nil, testErr
+					MockFindByID: func(ctx context.Context, id uint) (domain.Article, error) {
+						return domain.Article{}, testErr
 					},
 				},
 			},
@@ -148,7 +148,7 @@ func TestArticleService_GetArticle(t *testing.T) {
 				ctx: context.TODO(),
 				id:  testArticleFoo.ID,
 			},
-			want:       nil,
+			want:       domain.Article{},
 			wantErr:    true,
 			wantErrMsg: "s.repo.FindByID -> something happened",
 		},


### PR DESCRIPTION
It does cause the copying of the structs, but avoids heap allocation and more importantly, no nil checks needed.